### PR TITLE
Detect classes with encrypted action text attributes

### DIFF
--- a/test/dummy/app/models/comment.rb
+++ b/test/dummy/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  has_rich_text :content, encrypted: true
+end

--- a/test/dummy/db/migrate/20210423111601_create_comments.rb
+++ b/test/dummy/db/migrate/20210423111601_create_comments.rb
@@ -1,0 +1,7 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20210423115033_create_active_storage_tables.active_storage.rb
+++ b/test/dummy/db/migrate/20210423115033_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_094423) do
+ActiveRecord::Schema.define(version: 2021_04_23_115033) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -19,6 +19,39 @@ ActiveRecord::Schema.define(version: 2021_04_20_094423) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index [ "record_type", "record_id", "name" ], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index [ "blob_id" ], name: "index_active_storage_attachments_on_blob_id"
+    t.index [ "record_type", "record_id", "name", "blob_id" ], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index [ "key" ], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index [ "blob_id", "variation_digest" ], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "people", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -33,4 +66,7 @@ ActiveRecord::Schema.define(version: 2021_04_20_094423) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -6,8 +6,7 @@ class EncryptorTest < ActiveSupport::TestCase
       MassEncryption::Encryptor.new.encrypt_all_later(sequential: true)
     end
 
-    assert_encrypted_records Post.all
-    assert_encrypted_records Person.all
+    assert_everything_is_encrypted
   end
 
   test "encrypt all the records in parallel" do
@@ -15,8 +14,7 @@ class EncryptorTest < ActiveSupport::TestCase
       MassEncryption::Encryptor.new.encrypt_all_later(sequential: false)
     end
 
-    assert_encrypted_records Post.all
-    assert_encrypted_records Person.all
+    assert_everything_is_encrypted
   end
 
   test "provide classes to encrypt" do
@@ -25,6 +23,7 @@ class EncryptorTest < ActiveSupport::TestCase
     end
 
     assert_not_encrypted_records Post.all
+    assert_not_encrypted_records ActionText::EncryptedRichText.all
     assert_encrypted_records Person.all
   end
 
@@ -34,6 +33,7 @@ class EncryptorTest < ActiveSupport::TestCase
     end
 
     assert_encrypted_records Post.all
+    assert_encrypted_records ActionText::EncryptedRichText.all
     assert_not_encrypted_records Person.all
   end
 
@@ -61,5 +61,13 @@ class EncryptorTest < ActiveSupport::TestCase
     end
 
     assert_performed_jobs Post.count, only: MassEncryption::BatchEncryptionJob
+  end
+
+  test "encrypting includes encrypted rich texts attributes" do
+    perform_enqueued_jobs only: MassEncryption::BatchEncryptionJob do
+      MassEncryption::Encryptor.new.encrypt_all_later
+    end
+
+    assert_encrypted_records ActionText::EncryptedRichText.all
   end
 end

--- a/test/fixtures/action_text/encrypted_rich_texts.yml
+++ b/test/fixtures/action_text/encrypted_rich_texts.yml
@@ -1,0 +1,10 @@
+agree:
+  record: agree (Comment)
+  name: content
+  body: <p>I agree!</p>
+
+disagree:
+  record: disagree (Comment)
+  name: content
+  body: <p>I disagree!</p>
+

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,4 @@
+agree:
+  created_at: <%= 1.day.ago %>
+disagree:
+  created_at: <%= 1.day.ago %>

--- a/test/helpers/encryption_test_helper.rb
+++ b/test/helpers/encryption_test_helper.rb
@@ -1,5 +1,11 @@
 module EncryptionTestHelper
   private
+    def assert_everything_is_encrypted
+      assert_encrypted_records Post.all
+      assert_encrypted_records Person.all
+      assert_encrypted_records ActionText::EncryptedRichText.all
+    end
+
     def assert_encrypted_records(records)
       Array(records).each do |record|
         assert_encrypted_record record
@@ -18,7 +24,11 @@ module EncryptionTestHelper
       clear_value = record.public_send(attribute_name)
       encrypted_value = record.ciphertext_for(attribute_name)
 
-      assert_not_equal clear_value, encrypted_value
+      if record.is_a?(ActionText::EncryptedRichText)
+        assert_not clear_value.to_html.include?(encrypted_value)
+      else
+        assert_not_equal clear_value, encrypted_value
+      end
       assert_equal clear_value, record.class.type_for_attribute(attribute_name).deserialize(encrypted_value)
     end
 
@@ -40,6 +50,10 @@ module EncryptionTestHelper
       clear_value = record.public_send(attribute_name)
       encrypted_value = record.ciphertext_for(attribute_name)
 
-      assert_equal clear_value, encrypted_value
+      if record.is_a?(ActionText::EncryptedRichText)
+        assert clear_value.to_html.include?(encrypted_value)
+      else
+        assert_equal clear_value, encrypted_value
+      end
     end
 end


### PR DESCRIPTION
We encrypt action text as part of their containers models, but we were not detecting those properly.

@basecamp/sip 