### PR TITLE
Fallback to encrypting record by record when upsert_all fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
+    mocha (1.13.0)
     mysql2 (0.5.3)
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
@@ -166,6 +167,7 @@ PLATFORMS
 
 DEPENDENCIES
   mass_encryption!
+  mocha
   mysql2
   rails!
   rubocop

--- a/lib/mass_encryption.rb
+++ b/lib/mass_encryption.rb
@@ -6,5 +6,5 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module MassEncryption
-  # Your code goes here...
+  mattr_accessor :logger, default: ActiveSupport::Logger.new(STDOUT)
 end

--- a/lib/mass_encryption/batch_encryption_error.rb
+++ b/lib/mass_encryption/batch_encryption_error.rb
@@ -1,0 +1,9 @@
+class MassEncryption::BatchEncryptionError < StandardError
+  attr_reader :errors_by_record
+
+  def initialize(errors_by_record)
+    @errors_by_record = errors_by_record
+    message = errors_by_record.collect { |record, error| "[#{record.class}:#{record.id}] #{error.inspect}" }.join(", ")
+    super(message)
+  end
+end

--- a/lib/mass_encryption/encryptor.rb
+++ b/lib/mass_encryption/encryptor.rb
@@ -11,7 +11,7 @@ class MassEncryption::Encryptor
     @silent = silent
     @tracks_count = tracks_count
 
-    puts info_message unless silent
+    logger.info info_message unless silent
   end
 
   def encrypt_all_later

--- a/mass_encryption.gemspec
+++ b/mass_encryption.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "mocha"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require_relative "helpers/encryption_test_helper"
 ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 require "rails/test_help"
-
+require "mocha/minitest"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)


### PR DESCRIPTION
This makes that, when upsert_all fails with any kind of `StandardError`, it will try to encrypt the batch record by record. If some individual record fails to encrypt, it will collect the error and continue encrypting. After processing all the records, it will raise a single `MassEncryption::BatchEncryptionError` containing all the errors collected.

This is meant to handle edge-cases where, for example, a batch fails to encrypt because one record raises a "too long value" error.

See [todo](https://3.basecamp.com/2914079/buckets/24338625/todos/4287666312#__recording_4287707490) for context.

@basecamp/sip 
